### PR TITLE
ChatSpace DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,47 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+##Chatspace DB設計
+
+## messagesテーブル
+|Column|Type|Options|
+|:------|:----|:-------|
+|body|text||
+|image|string||
+|group_id|integer|null :false, foreign_key:true|
+|user_id|integer|null :false, foreign_key:true|
+ ## Association
+ - belongs_to :user
+ - belongs_to :group
+
+ ## usersテーブル
+|Column|Type|Options|
+|:------|:----|:-------|
+|name|string|null :false, add_index:true|
+|e-mail|string|null :false, unique:true|
+ ## Association
+ - has_many :groups_users
+ - has_many :groups, through: groups_users
+ - has_many :messages
+
+ ## groupsテーブル
+|Column|Type|Options|
+|:------|:----|:-------|
+|group_name|string|null :false,unique:true|
+|message_id|integer|null :false|
+|user_id|integer|null :false|
+ ## Association
+ - has_many :groups_users
+ - has_many :users, through: groups_users
+ - has_many :messages
+
+
+ ## groups_usersテーブ
+|Column|Type|Options|
+|:------|:----|:-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ Things you may want to cover:
  ## groupsテーブル
 |Column|Type|Options|
 |:------|:----|:-------|
-|group_name|string|null :false,unique:true|
-|message_id|integer|null :false|
-|user_id|integer|null :false|
+|name|string|null :false,unique:true|
  ## Association
  - has_many :groups_users
  - has_many :users, through: groups_users


### PR DESCRIPTION
# what
修正点のgroupsテーブルのカラム名をgroup_nameからnameに変更
同じくgroupsテーブルのmessage_idとuser_idのカラムを削除した

READMEにアプリ「ChatSpace」の作成に必要なDB作成の為の要素を洗い出し書き出し設計した

# why
groupsテーブルにはnameというカラムが１つも存在しないため、より簡潔なカラム名に変更
message_idとuser_idが不要なのはmessegesテーブルから外部キーとしてgroupsテーブルへは紐付けされ、さらにusersテーブルはgroups_usersテーブルを経由してアソシエーションされているため不要となる

アプリ作成に必要なDBの作成を行う前に、事前に機能の実装に必要な要素を確認するため。
