### PR TITLE
Edit scss haml

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,4 @@
+@import "reset";
+@import "modules/messages";
+@import "font-awesome-sprockets";
+@import "font-awesome";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
 Rails.application.routes.draw do
-  get 'messages/index'
-
   root "messages#index"
 end


### PR DESCRIPTION
# what
・フロント画面のビューに反映させるコード記述に使用するため、各種ファイルを紐付けした
・routesファイルは余計な記述を削除した

# why
フロント実装に必要なリセットcssの「reset.scssファイル」・実際に記述を行なっていくファイルの「modules/messagesファイル」・使用フォントを修飾してくれるGemの「font-awesome-sprocketsファイル」と「font-awesomeファイル」をフロント実装で使用しているということがわかるように一箇所のディレクトリに紐付けした

routesの記述は同じファイル内にrootメソッドが存在したためgetを削除した